### PR TITLE
Add example FastAPI project

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,1 +1,54 @@
-pytest
+name: Deploy MELANO INC
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run tests
+        run: pytest
+
+      - name: Lint code
+        run: flake8 .
+
+      - name: Build Docker image
+        run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/melano-inc:latest .
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push Docker image
+        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/melano-inc:latest
+
+      - name: Deploy to server
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          script: |
+            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/melano-inc:latest
+            docker stop melano-inc || true
+            docker rm melano-inc || true
+            docker run -d --name melano-inc -p 80:80 ${{ secrets.DOCKERHUB_USERNAME }}/melano-inc:latest
+
+      - name: Notify Slack (via Chronos)
+        run: |
+          curl -X POST -H 'Content-type: application/json' --data '{"text":"🚀 MELANO INC desplegado correctamente."}' ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn", "melania.main:app", "--host", "0.0.0.0", "--port", "80"]

--- a/README.md
+++ b/README.md
@@ -38,3 +38,16 @@ MELANO INC – Documentación Técnica de Arquitectura con Agentes IA Interconec
 - Auto-deploy si tests y linters pasan
 - Notificaciones en Slack vía Agent Chronos
 
+
+## 🚀 Quickstart
+
+```bash
+# Install dependencies
+pip install -r requirements.txt
+
+# Run development server
+uvicorn melania.main:app --reload
+
+# Run tests
+pytest
+```

--- a/melania/__init__.py
+++ b/melania/__init__.py
@@ -1,0 +1,1 @@
+"""MELANO INC core package"""

--- a/melania/agents/ares.py
+++ b/melania/agents/ares.py
@@ -1,0 +1,9 @@
+from fastapi import APIRouter
+
+
+router = APIRouter()
+
+
+@router.get("/")
+def status() -> dict:
+    return {"ares": "online"}

--- a/melania/agents/athena.py
+++ b/melania/agents/athena.py
@@ -1,0 +1,9 @@
+from fastapi import APIRouter
+
+
+router = APIRouter()
+
+
+@router.get("/")
+def status() -> dict:
+    return {"athena": "online"}

--- a/melania/agents/chronos.py
+++ b/melania/agents/chronos.py
@@ -1,0 +1,9 @@
+from fastapi import APIRouter
+
+
+router = APIRouter()
+
+
+@router.get("/")
+def status() -> dict:
+    return {"chronos": "online"}

--- a/melania/agents/hermes.py
+++ b/melania/agents/hermes.py
@@ -1,0 +1,9 @@
+from fastapi import APIRouter
+
+
+router = APIRouter()
+
+
+@router.get("/")
+def status() -> dict:
+    return {"hermes": "online"}

--- a/melania/main.py
+++ b/melania/main.py
@@ -1,0 +1,16 @@
+from fastapi import FastAPI
+from .agents import hermes, ares, chronos, athena
+
+
+app = FastAPI(title="MELANO INC")
+
+
+app.include_router(hermes.router, prefix="/hermes", tags=["hermes"])
+app.include_router(ares.router, prefix="/ares", tags=["ares"])
+app.include_router(chronos.router, prefix="/chronos", tags=["chronos"])
+app.include_router(athena.router, prefix="/athena", tags=["athena"])
+
+
+@app.get("/")
+def read_root() -> dict:
+    return {"message": "MELANO INC API Online"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+pytest
+flake8
+httpx==0.24.1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, BASE_DIR)
+
+from fastapi.testclient import TestClient  # noqa: E402
+from melania.main import app  # noqa: E402
+
+
+client = TestClient(app)
+
+
+def test_read_root() -> None:
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "MELANO INC API Online"}


### PR DESCRIPTION
## Summary
- add minimal FastAPI app with agents
- provide Dockerfile, requirements and test
- implement deployment workflow example
- update README with quickstart instructions

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845f76c2b14832497f89187dd50c533