### PR TITLE
Implement conversation logging and training pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+melania/conversations.db
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -51,3 +51,14 @@ uvicorn melania.main:app --reload
 # Run tests
 pytest
 ```
+
+## 📚 Conversaciones y entrenamiento
+
+El endpoint `POST /hermes/chat` almacena cada mensaje y la respuesta generada en
+una base de datos SQLite en `melania/conversations.db`. El script
+`melania/train.py` carga esas conversaciones para entrenar un modelo de ejemplo
+con `scikit-learn`.
+
+```bash
+python -m melania.train
+```

--- a/melania/agents/hermes.py
+++ b/melania/agents/hermes.py
@@ -1,4 +1,11 @@
 from fastapi import APIRouter
+from pydantic import BaseModel
+from ..conversations import log_conversation
+
+
+class Message(BaseModel):
+    user_id: str
+    message: str
 
 
 router = APIRouter()
@@ -7,3 +14,17 @@ router = APIRouter()
 @router.get("/")
 def status() -> dict:
     return {"hermes": "online"}
+
+
+@router.post("/chat")
+def chat(message: Message) -> dict:
+    """Simple chat endpoint that logs the conversation."""
+    # Placeholder response generation
+    respuesta = "Hola, soy Melania"
+    log_conversation(
+        user_id=message.user_id,
+        mensaje_usuario=message.message,
+        respuesta_melania=respuesta,
+        etiquetas=[],
+    )
+    return {"respuesta": respuesta}

--- a/melania/conversations.py
+++ b/melania/conversations.py
@@ -1,0 +1,42 @@
+import sqlite3
+import json
+from pathlib import Path
+from typing import List
+
+DB_PATH = Path(__file__).resolve().parent / "conversations.db"
+
+
+def init_db() -> None:
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        """
+        CREATE TABLE IF NOT EXISTS conversations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT,
+            mensaje_usuario TEXT,
+            respuesta_melania TEXT,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+            etiquetas TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def log_conversation(
+    user_id: str,
+    mensaje_usuario: str,
+    respuesta_melania: str,
+    etiquetas: List[str] | None = None,
+) -> None:
+    init_db()
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        "INSERT INTO conversations (user_id, mensaje_usuario, respuesta_melania, etiquetas) VALUES (?, ?, ?, ?)",
+        (user_id, mensaje_usuario, respuesta_melania, json.dumps(etiquetas or [])),
+    )
+    conn.commit()
+    conn.close()

--- a/melania/train.py
+++ b/melania/train.py
@@ -1,0 +1,40 @@
+"""Simple training script using logged conversations."""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline
+
+DB_PATH = Path(__file__).resolve().parent / "conversations.db"
+
+
+def load_data():
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute("SELECT mensaje_usuario, respuesta_melania FROM conversations")
+    rows = c.fetchall()
+    conn.close()
+    texts = [row[0] for row in rows]
+    labels = [row[1] for row in rows]
+    return texts, labels
+
+
+def train_model():
+    texts, labels = load_data()
+    if not texts:
+        print("No conversations to train on")
+        return
+    pipeline = Pipeline([
+        ("tfidf", TfidfVectorizer()),
+        ("clf", LogisticRegression()),
+    ])
+    pipeline.fit(texts, labels)
+    print(f"Trained model on {len(texts)} conversations")
+
+
+if __name__ == "__main__":
+    train_model()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 pytest
 flake8
 httpx==0.24.1
+scikit-learn

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,3 +15,10 @@ def test_read_root() -> None:
     response = client.get("/")
     assert response.status_code == 200
     assert response.json() == {"message": "MELANO INC API Online"}
+
+
+def test_chat_endpoint() -> None:
+    payload = {"user_id": "test", "message": "hola"}
+    response = client.post("/hermes/chat", json=payload)
+    assert response.status_code == 200
+    assert "respuesta" in response.json()


### PR DESCRIPTION
## Summary
- log conversations to a SQLite database
- expose `/hermes/chat` endpoint that stores user messages
- add a simple training script using scikit-learn
- document how to train and run new endpoint
- cover new endpoint with tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f86858448324814ea904e3dec503