### PR TITLE
Improve chat model loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+melania/conversations.db
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -51,3 +51,16 @@ uvicorn melania.main:app --reload
 # Run tests
 pytest
 ```
+
+## 📚 Conversaciones y entrenamiento
+
+El endpoint `POST /hermes/chat` almacena cada mensaje y la respuesta generada en
+una base de datos SQLite en `melania/conversations.db`. El script
+`melania/train.py` carga esas conversaciones para entrenar un modelo de ejemplo
+con `scikit-learn` y guarda el resultado en `melania/model.joblib`.
+Cuando ese archivo existe, el endpoint `/hermes/chat` lo utiliza para predecir
+la respuesta. En caso contrario, devuelve una respuesta por defecto.
+
+```bash
+python -m melania.train
+```

--- a/melania/agents/hermes.py
+++ b/melania/agents/hermes.py
@@ -1,4 +1,20 @@
 from fastapi import APIRouter
+from pydantic import BaseModel
+from pathlib import Path
+import joblib
+from ..conversations import log_conversation
+
+MODEL_PATH = Path(__file__).resolve().parent.parent / "model.joblib"
+
+try:
+    MODEL = joblib.load(MODEL_PATH)
+except FileNotFoundError:
+    MODEL = None
+
+
+class Message(BaseModel):
+    user_id: str
+    message: str
 
 
 router = APIRouter()
@@ -7,3 +23,20 @@ router = APIRouter()
 @router.get("/")
 def status() -> dict:
     return {"hermes": "online"}
+
+
+@router.post("/chat")
+def chat(message: Message) -> dict:
+    """Simple chat endpoint that logs the conversation."""
+    if MODEL:
+        respuesta = MODEL.predict([message.message])[0]
+    else:
+        # Fallback response if no model is available
+        respuesta = "Hola, soy Melania"
+    log_conversation(
+        user_id=message.user_id,
+        mensaje_usuario=message.message,
+        respuesta_melania=respuesta,
+        etiquetas=[],
+    )
+    return {"respuesta": respuesta}

--- a/melania/conversations.py
+++ b/melania/conversations.py
@@ -1,0 +1,42 @@
+import sqlite3
+import json
+from pathlib import Path
+from typing import List
+
+DB_PATH = Path(__file__).resolve().parent / "conversations.db"
+
+
+def init_db() -> None:
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        """
+        CREATE TABLE IF NOT EXISTS conversations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT,
+            mensaje_usuario TEXT,
+            respuesta_melania TEXT,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+            etiquetas TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def log_conversation(
+    user_id: str,
+    mensaje_usuario: str,
+    respuesta_melania: str,
+    etiquetas: List[str] | None = None,
+) -> None:
+    init_db()
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        "INSERT INTO conversations (user_id, mensaje_usuario, respuesta_melania, etiquetas) VALUES (?, ?, ?, ?)",
+        (user_id, mensaje_usuario, respuesta_melania, json.dumps(etiquetas or [])),
+    )
+    conn.commit()
+    conn.close()

--- a/melania/train.py
+++ b/melania/train.py
@@ -1,0 +1,43 @@
+"""Simple training script using logged conversations."""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline
+import joblib
+
+MODEL_PATH = Path(__file__).resolve().parent / "model.joblib"
+
+DB_PATH = Path(__file__).resolve().parent / "conversations.db"
+
+
+def load_data():
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute("SELECT mensaje_usuario, respuesta_melania FROM conversations")
+    rows = c.fetchall()
+    conn.close()
+    texts = [row[0] for row in rows]
+    labels = [row[1] for row in rows]
+    return texts, labels
+
+
+def train_model():
+    texts, labels = load_data()
+    if not texts:
+        print("No conversations to train on")
+        return
+    pipeline = Pipeline([
+        ("tfidf", TfidfVectorizer()),
+        ("clf", LogisticRegression()),
+    ])
+    pipeline.fit(texts, labels)
+    joblib.dump(pipeline, MODEL_PATH)
+    print(f"Trained model on {len(texts)} conversations and saved to {MODEL_PATH}")
+
+
+if __name__ == "__main__":
+    train_model()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ uvicorn
 pytest
 flake8
 httpx==0.24.1
+scikit-learn
+joblib

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,3 +15,10 @@ def test_read_root() -> None:
     response = client.get("/")
     assert response.status_code == 200
     assert response.json() == {"message": "MELANO INC API Online"}
+
+
+def test_chat_endpoint() -> None:
+    payload = {"user_id": "test", "message": "hola"}
+    response = client.post("/hermes/chat", json=payload)
+    assert response.status_code == 200
+    assert "respuesta" in response.json()


### PR DESCRIPTION
## Summary
- load trained model if available in `/hermes/chat`
- save model to disk in `melania/train.py`
- document model usage in README
- explicitly list `joblib` dependency

## Testing
- `flake8 --ignore=E501`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f86858448324814ea904e3dec503

## Resumen por Sourcery

Habilita el entrenamiento y el servicio persistente del modelo de chat registrando interacciones, entrenando un modelo de scikit-learn, cargándolo en la API con comportamiento de respaldo y documentando el flujo de trabajo

Nuevas características:
- Carga y sirve un modelo de chat ML entrenado en /hermes/chat con una respuesta de respaldo predeterminada
- Introduce un script de entrenamiento para construir y guardar un pipeline de scikit-learn a partir de conversaciones registradas
- Registra las interacciones del chat en una base de datos SQLite para el entrenamiento del modelo

Mejoras:
- Añade una respuesta de respaldo cuando no hay un modelo entrenado disponible
- Documenta el flujo de trabajo de entrenamiento y uso del modelo en el README

Compilación:
- Añade scikit-learn y joblib a las dependencias del proyecto

Documentación:
- Documenta el registro conversacional y la persistencia del modelo en el README

Pruebas:
- Añade una prueba de integración para el endpoint /hermes/chat

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable persistent chat model training and serving by logging interactions, training a scikit-learn model, loading it in the API with fallback behavior, and documenting the workflow

New Features:
- Load and serve a trained ML chat model at /hermes/chat with a default fallback response
- Introduce a training script to build and save a scikit-learn pipeline from logged conversations
- Log chat interactions to a SQLite database for model training

Enhancements:
- Add fallback response when no trained model is available
- Document model training and usage workflow in the README

Build:
- Add scikit-learn and joblib to project dependencies

Documentation:
- Document conversational logging and model persistence in README

Tests:
- Add integration test for the /hermes/chat endpoint

</details>