### PR TITLE
Add system status endpoint for agent integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ uvicorn melania.main:app --reload
 pytest
 ```
 
+## 🛰️ Estado del ecosistema
+
+El endpoint `GET /status` devuelve el estado de todos los agentes conectados.
+
 ## 📚 Conversaciones y entrenamiento
 
 El endpoint `POST /hermes/chat` almacena cada mensaje y la respuesta generada en

--- a/melania/main.py
+++ b/melania/main.py
@@ -14,3 +14,14 @@ app.include_router(athena.router, prefix="/athena", tags=["athena"])
 @app.get("/")
 def read_root() -> dict:
     return {"message": "MELANO INC API Online"}
+
+
+@app.get("/status")
+def system_status() -> dict:
+    """Return the availability of all agents."""
+    return {
+        "hermes": hermes.status()["hermes"],
+        "ares": ares.status()["ares"],
+        "chronos": chronos.status()["chronos"],
+        "athena": athena.status()["athena"],
+    }

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,6 +17,17 @@ def test_read_root() -> None:
     assert response.json() == {"message": "MELANO INC API Online"}
 
 
+def test_system_status() -> None:
+    response = client.get("/status")
+    assert response.status_code == 200
+    assert response.json() == {
+        "hermes": "online",
+        "ares": "online",
+        "chronos": "online",
+        "athena": "online",
+    }
+
+
 def test_chat_endpoint() -> None:
     payload = {"user_id": "test", "message": "hola"}
     response = client.post("/hermes/chat", json=payload)


### PR DESCRIPTION
## Summary
- expose `/status` endpoint showing availability of all agents
- test system status and document new endpoint

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aae8c87870832486009d580df5fb02