### PR TITLE
Implement Hermes chat endpoint with logging

### DIFF
--- a/melania/agents/hermes.py
+++ b/melania/agents/hermes.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter
 from pydantic import BaseModel
 
+from ..conversations import log_conversation
+
 
 class Message(BaseModel):
     user_id: str
@@ -18,7 +20,7 @@ def status() -> dict:
 @router.post("/chat")
 def chat(message: Message) -> dict:
     """Simple chat endpoint that logs the conversation."""
-
+    respuesta = f"Echo: {message.message}"
     log_conversation(
         user_id=message.user_id,
         mensaje_usuario=message.message,

--- a/melania/conversations.py
+++ b/melania/conversations.py
@@ -35,8 +35,16 @@ def log_conversation(
     conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
     c.execute(
-        "INSERT INTO conversations (user_id, mensaje_usuario, respuesta_melania, etiquetas) VALUES (?, ?, ?, ?)",
-        (user_id, mensaje_usuario, respuesta_melania, json.dumps(etiquetas or [])),
+        (
+            "INSERT INTO conversations (user_id, mensaje_usuario, "
+            "respuesta_melania, etiquetas) VALUES (?, ?, ?, ?)"
+        ),
+        (
+            user_id,
+            mensaje_usuario,
+            respuesta_melania,
+            json.dumps(etiquetas or []),
+        ),
     )
     conn.commit()
     conn.close()

--- a/melania/train.py
+++ b/melania/train.py
@@ -26,7 +26,15 @@ def load_data():
 def train_model():
     texts, labels = load_data()
     if not texts:
-
+        return None
+    pipeline = Pipeline(
+        [
+            ("vectorizer", TfidfVectorizer()),
+            ("classifier", LogisticRegression(max_iter=1000)),
+        ]
+    )
+    pipeline.fit(texts, labels)
+    return pipeline
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add logging and echo response to Hermes chat endpoint
- Reformat conversation persistence and complete training script stub

## Testing
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7cf3d639c8324845033cd2f42c96a